### PR TITLE
104. Maximum Depth of Binary Tree

### DIFF
--- a/leetcode/max-depth-binary-tree.ts
+++ b/leetcode/max-depth-binary-tree.ts
@@ -1,0 +1,9 @@
+import { TreeNode } from "../types";
+
+export function maxDepth(root: TreeNode | null): number {
+	if (!root) {
+		return 0;
+	}
+
+	return 1 + Math.max(maxDepth(root.left), maxDepth(root.right));
+}

--- a/leetcode/max-depth-binary-tree.ts
+++ b/leetcode/max-depth-binary-tree.ts
@@ -1,9 +1,49 @@
 import { TreeNode } from "../types";
+import { Queue } from "typescript-collections";
 
+// Depth First Search
 export function maxDepth(root: TreeNode | null): number {
 	if (!root) {
 		return 0;
 	}
 
 	return 1 + Math.max(maxDepth(root.left), maxDepth(root.right));
+}
+
+// Iterative Depth First Search
+export function maxDepth_DFS(root: TreeNode | null): number {
+	let stack: [TreeNode | null, number][] = [[root, 1]];
+	let lvl = 0;
+
+	while (stack.length > 0) {
+		let [node, depth] = stack.pop()!;
+		if (node) {
+			lvl = Math.max(lvl, depth);
+			stack.push([node.left, depth + 1]);
+			stack.push([node.right, depth + 1]);
+		}
+	}
+	return lvl;
+}
+
+// Iterative Breath First Search
+export function maxDepth_BFS(root: TreeNode | null): number {
+	if (!root) return 0;
+
+	let lvl = 0;
+	let queue = new Queue<TreeNode>();
+	queue.add(root);
+	while (queue.size()) {
+		for (let i = 0; i < queue.size(); ++i) {
+			let node = queue.dequeue();
+			if (node?.left) {
+				queue.add(node.left);
+			}
+			if (node?.right) {
+				queue.add(node.right);
+			}
+		}
+		lvl++;
+	}
+	return lvl;
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "typescript": "^5.0.4"
+    "typescript": "^5.0.4",
+    "typescript-collections": "^1.3.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.5",

--- a/tests/max-depth-binary-tree.test.ts
+++ b/tests/max-depth-binary-tree.test.ts
@@ -1,0 +1,42 @@
+import { maxDepth } from "../leetcode/max-depth-binary-tree";
+import { TreeNode } from "../types";
+
+describe("maxDepth", () => {
+	it("should return 3 for [3,9,20,null,null,15,7]", () => {
+		const root: TreeNode = {
+			val: 3,
+			left: {
+				val: 9,
+				left: null,
+				right: null,
+			},
+			right: {
+				val: 20,
+				left: {
+					val: 15,
+					left: null,
+					right: null,
+				},
+				right: {
+					val: 7,
+					left: null,
+					right: null,
+				},
+			},
+		};
+		expect(maxDepth(root)).toBe(3);
+	});
+
+	it("should return 2 for [1,null,2]", () => {
+		const root: TreeNode = {
+			val: 1,
+			left: null,
+			right: {
+				val: 2,
+				left: null,
+				right: null,
+			},
+		};
+		expect(maxDepth(root)).toBe(2);
+	});
+});

--- a/tests/max-depth-binary-tree.test.ts
+++ b/tests/max-depth-binary-tree.test.ts
@@ -1,4 +1,4 @@
-import { maxDepth } from "../leetcode/max-depth-binary-tree";
+import { maxDepth_DFS, maxDepth_BFS, maxDepth } from "../leetcode/max-depth-binary-tree";
 import { TreeNode } from "../types";
 
 describe("maxDepth", () => {
@@ -38,5 +38,61 @@ describe("maxDepth", () => {
 			},
 		};
 		expect(maxDepth(root)).toBe(2);
+	});
+});
+
+describe("maxDepth_DFS", () => {
+	it("should return 0 for null root", () => {
+		expect(maxDepth_DFS(null)).toBe(0);
+	});
+
+	it("should return 1 for single node tree", () => {
+		expect(maxDepth_DFS({ val: 1, left: null, right: null })).toBe(1);
+	});
+
+	it("should return correct depth for example 1", () => {
+		const root = {
+			val: 3,
+			left: { val: 9, left: null, right: null },
+			right: {
+				val: 20,
+				left: { val: 15, left: null, right: null },
+				right: { val: 7, left: null, right: null },
+			},
+		};
+		expect(maxDepth_DFS(root)).toBe(3);
+	});
+
+	it("should return correct depth for example 2", () => {
+		const root = { val: 1, left: null, right: { val: 2, left: null, right: null } };
+		expect(maxDepth_DFS(root)).toBe(2);
+	});
+});
+
+describe("maxDepth_BFS", () => {
+	it("should return 0 for null root", () => {
+		expect(maxDepth_BFS(null)).toBe(0);
+	});
+
+	it("should return 1 for single node tree", () => {
+		expect(maxDepth_BFS({ val: 1, left: null, right: null })).toBe(1);
+	});
+
+	it("should return correct depth for example 1", () => {
+		const root = {
+			val: 3,
+			left: { val: 9, left: null, right: null },
+			right: {
+				val: 20,
+				left: { val: 15, left: null, right: null },
+				right: { val: 7, left: null, right: null },
+			},
+		};
+		expect(maxDepth_BFS(root)).toBe(3);
+	});
+
+	it("should return correct depth for example 2", () => {
+		const root = { val: 1, left: null, right: { val: 2, left: null, right: null } };
+		expect(maxDepth_BFS(root)).toBe(2);
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1650,7 +1650,7 @@ human-signals@^4.3.0:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz"
   integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
 
-husky@^8.0.3:
+husky@^8.0.0:
   version "8.0.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
   integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
@@ -3171,6 +3171,11 @@ type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+
+typescript-collections@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/typescript-collections/-/typescript-collections-1.3.3.tgz#62d50d93c018c094d425eabee649f00ec5cc0fea"
+  integrity sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ==
 
 "typescript@^4.6.4 || ^5.0.0":
   version "5.1.3"


### PR DESCRIPTION
Given the root of a binary tree, return its maximum depth.

A binary tree's maximum depth is the number of nodes along the longest path from the root node down to the farthest leaf node.

 

Example 1:
![tmp-tree](https://github.com/RadhiRasho/LeetCode-Problems-TS/assets/54078496/1ffe19af-8b38-4119-b207-0f11c70e7b28)

```
Input: root = [3,9,20,null,null,15,7]
Output: 3
```

Example 2:
```
Input: root = [1,null,2]
Output: 2
 ```

Constraints:

* The number of nodes in the tree is in the range `[0, 104]`.
* `-100 <= Node.val <= 100`